### PR TITLE
refactor: changed file path to manifest.xml to asset specification object

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -1361,7 +1361,12 @@
                                 "output": "/"
                             },
                             "apps/outlook-rooms-addin/src/manifest.webmanifest",
-                            "apps/outlook-rooms-addin/manifest.xml"
+
+                            {
+                                "glob": "manifest.xml",
+                                "input": "apps/outlook-rooms-addin/",
+                                "output": "/"
+                            }
                         ],
                         "styles": [
                             "./node_modules/@angular/material/prebuilt-themes/indigo-pink.css",


### PR DESCRIPTION

**Description of the change**

In the Build configurations of the Outlook Add-in project, the path to the `manifest.xml` asset was throwing an error saying `apps/outlook-rooms-add/manifest.xml asset path must start with the project source root`. To get past this error, the asset path was changed from a simple path to a specification object. (The manifest.xml file isn't located in the /src folder)

**Benefits**

Avoids above error message.

**Possible drawbacks**
N/A

**Applicable issues**
N/A

**Additional information**
N/A
