### PR TITLE
Feat/outlook rooms addin

### DIFF
--- a/apps/outlook-rooms-addin/src/app/rooms/room-booking.component.html
+++ b/apps/outlook-rooms-addin/src/app/rooms/room-booking.component.html
@@ -85,6 +85,24 @@
                         formControlName="attendees"
                         class="text-sm"
                     ></a-user-list-field>
+
+                    <!-- <div class="bg-red-300" height="500" width="500">
+                        <i-frame
+                            frameborder="0"
+                            width="420"
+                            height="345"
+                            src="https://microsoft.poc.placeos.com/outlook/"
+                            allowfullscreen
+                        ></i-frame>
+                    </div> -->
+
+                    <button
+                        type="submit"
+                        target="_parent"
+                        (click)="downloadTemplate()"
+                    >
+                        DOWNLOAD
+                    </button>
                 </div>
             </div>
         </section>

--- a/apps/outlook-rooms-addin/src/app/rooms/room-booking.component.html
+++ b/apps/outlook-rooms-addin/src/app/rooms/room-booking.component.html
@@ -85,23 +85,16 @@
                         formControlName="attendees"
                         class="text-sm"
                     ></a-user-list-field>
-
-                    <!-- <div class="bg-red-300" height="500" width="500">
-                        <i-frame
-                            frameborder="0"
-                            width="420"
-                            height="345"
-                            src="https://microsoft.poc.placeos.com/outlook/"
-                            allowfullscreen
-                        ></i-frame>
-                    </div> -->
-
                     <button
+                        mat-button
                         type="submit"
                         target="_parent"
                         (click)="downloadTemplate()"
+                        class="absolute z-100 mt-[74px] ml-[245px] w-[150px] bg-white text-secondary border-secondary"
                     >
-                        DOWNLOAD
+                        <div class="flex items-center justify-center">
+                            <span> CSV Template </span>
+                        </div>
                     </button>
                 </div>
             </div>

--- a/apps/outlook-rooms-addin/src/app/rooms/room-booking.component.ts
+++ b/apps/outlook-rooms-addin/src/app/rooms/room-booking.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Inject } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 import { Router } from '@angular/router';
 import { EventFormService } from '@placeos/events';
 
@@ -37,7 +38,11 @@ export class RoomBookingComponent implements OnInit {
         this._state.clearForm();
     };
 
-    constructor(private router: Router, private _state: EventFormService) {}
+    constructor(
+        @Inject(DOCUMENT) private _document: Document,
+        private router: Router,
+        private _state: EventFormService
+    ) {}
 
     ngOnInit(): void {
         this._state.newForm();
@@ -55,5 +60,9 @@ export class RoomBookingComponent implements OnInit {
         await this._state.storeForm();
 
         this.router.navigate(['/schedule/view']);
+    }
+
+    downloadTemplate() {
+        window.open('assets/template.csv');
     }
 }

--- a/apps/outlook-rooms-addin/src/assets/template.csv
+++ b/apps/outlook-rooms-addin/src/assets/template.csv
@@ -1,0 +1,2 @@
+Organisation,First Name,Last Name,Email,Phone,Assistance Required,Visit Expected
+Fake Org,John,Smith,john.smith@example.com,01234567898,false,true


### PR DESCRIPTION
**Description of the change**

Attempt to trigger download of CSV template inside Outlook Add-in. 

Issue: the Outlook Desktop App blocks the `anchor` element's href hyperlink which contains the template to be downloaded. 

Alternatives explored:
- tried opening the anchor link in an iframe to avoid redirect
- considered adding the href url as an AppDomain to the manifest.xml file but there is the issue of generating dynamic urls
- looked at the `save-file` npm package but it uses the same `a[download]` method which is the existing method

**Benefits**
Attempt to allow download function to work inside Outlook Addin

**Possible drawbacks**

Couldn't test this inside Outlook Addin until it's deployed due to auth issues

**Applicable issues**
#160 

**Additional information**
N/A
