### PR TITLE
chore(concierge/report): rename 6 columns

### DIFF
--- a/apps/concierge/src/app/reports/spaces/report-spaces-space-listing.component.ts
+++ b/apps/concierge/src/app/reports/spaces/report-spaces-space-listing.component.ts
@@ -135,21 +135,21 @@ export class ReportSpacesSpaceListing {
             !_
                 ? [
                       'Name',
-                      'Capacity',
-                      'Meeting Count',
-                      'Utilisation',
-                      'Avg. Attendees',
+                      'Room Capacity',
+                      'Bookings',
+                      '% Time booked during office hrs',
+                      'Avg. invitees per booking',
                       'Occupancy',
                   ]
                 : [
                       'Name',
-                      'Capacity',
-                      'Meeting Count',
-                      'Utilisation',
-                      'Avg. Attendees',
+                      'Room Capacity',
+                      'Bookings',
+                      '% Time booked during office hrs',
+                      'Avg. invitees per booking',
                       'Occupancy',
-                      'Attendance',
-                      'Avg. Attendance',
+                      'Total In-room Attendance',
+                      'Avg. In-room Attendance',
                   ]
         )
     );


### PR DESCRIPTION
With the addition of the in-room ppl counts, the term "invitees" substitutes "attendees" to clarify that they are not physical in-room attendees.