### PR TITLE
feat(workplace): switch to websocket subscription instead of freebusy…

### DIFF
--- a/apps/workplace/src/app/landing/landing-availability.component.ts
+++ b/apps/workplace/src/app/landing/landing-availability.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { SettingsService } from '@placeos/common';
 import { OrganisationService } from '@placeos/organisation';
+import { Space } from '@placeos/spaces';
 import { LandingStateService } from './landing-state.service';
 
 @Component({
@@ -80,7 +81,10 @@ import { LandingStateService } from './landing-state.service';
             >
                 <button
                     matRipple
-                    *ngFor="let space of space_list | async"
+                    *ngFor="
+                        let space of space_list | async;
+                        trackBy: trackBySpaceId
+                    "
                     class="flex items-center h-24 min-w-[12.5rem] rounded-lg bg-white dark:bg-[#1F2021] shadow p-4 space-x-2"
                     [routerLink]="['/explore']"
                     [queryParams]="{ space: space.email }"
@@ -139,6 +143,10 @@ export class LandingAvailabilityComponent {
     public readonly loading_spaces = this._state.loading_spaces;
     public readonly levels_free = this._state.level_occupancy;
 
+    public trackBySpaceId(index: number, space: Space) {
+        return space.id;
+    }
+
     public building(id: string) {
         return this._org.buildings.find((bld) => bld.id === id);
     }
@@ -158,7 +166,7 @@ export class LandingAvailabilityComponent {
     ) {}
 
     public async ngOnInit() {
-        this._state.loadFreeSpaces();
+        // this._state.loadFreeSpaces();
     }
 
     public ngOnDestroy() {

--- a/libs/spaces/src/lib/spaces-status.service.ts
+++ b/libs/spaces/src/lib/spaces-status.service.ts
@@ -1,0 +1,73 @@
+import { Injectable } from '@angular/core';
+import { BaseClass, HashMap } from '@placeos/common';
+import { getModule } from '@placeos/ts-client';
+import { BehaviorSubject, combineLatest } from 'rxjs';
+import { filter, first, map } from 'rxjs/operators';
+import { SpacesService } from './spaces.service';
+
+export interface SpaceStates {
+    status: string;
+}
+
+@Injectable({
+    providedIn: 'root',
+})
+export class SpacesStatusService extends BaseClass {
+    /** Subject to store statuses of spaces */
+    private _list_status = new BehaviorSubject<HashMap>({});
+    /** Observable of statuses of spaces */
+    public readonly list_status = this._list_status.asObservable();
+
+    public readonly list_free_spaces = combineLatest([
+        this._spaces.list,
+        this.list_status,
+    ]).pipe(
+        map(([list, list_status]) =>
+            list.filter((e) => list_status[e.id] === 'free')
+        )
+    );
+
+    constructor(private _spaces: SpacesService) {
+        super();
+        this._init();
+    }
+
+    private async _init() {
+        await this._spaces.initialised.pipe(first()).toPromise();
+        // bind property
+        this._spaces.list.pipe(filter((_) => !!_)).subscribe((list) => {
+            const list_ids = list.map((_) => _.id);
+            list_ids.forEach((e) => this.bindTo(e, 'status'));
+        });
+        this._initialised.next(true);
+    }
+
+    /** List to binding */
+    private bindTo<K extends keyof SpaceStates>(
+        id: string,
+        name: string,
+        mod: string = 'Bookings',
+        on_change: (v: SpaceStates[K]) => void = (v) =>
+            this.updateProperty(id, name, v)
+    ) {
+        const binding = getModule(id, mod).binding(name);
+        this.subscription(
+            `listen:${id}-${name}`,
+            binding.listen().subscribe(on_change)
+        );
+        this.subscription(`bind:${name}`, binding.bind());
+    }
+
+    /** Update properties of the system data */
+    private updateProperty<K extends keyof SpaceStates>(
+        id: string,
+        name: string,
+        value: SpaceStates[K]
+    ) {
+        if (!value) return;
+        const lists = { ...this._list_status.getValue() };
+        let item = lists[id] || {};
+        lists[id] = item[name] = value;
+        this._list_status.next(lists);
+    }
+}

--- a/libs/spaces/src/lib/spaces.ts
+++ b/libs/spaces/src/lib/spaces.ts
@@ -4,4 +4,5 @@ export * from './space.class';
 export * from './space.utilities';
 export * from './spaces.module';
 export * from './spaces.service';
+export * from './spaces-status.service';
 export * from './space-select-modal/new-space-select-modal.component';

--- a/libs/spaces/src/tests/space-status.service.spec.ts
+++ b/libs/spaces/src/tests/space-status.service.spec.ts
@@ -1,0 +1,28 @@
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator"
+import { MockProvider } from "ng-mocks";
+import { of } from "rxjs";
+import { Space } from "../lib/space.class";
+import { SpacesStatusService } from "../lib/spaces-status.service"
+import { SpacesService } from "../lib/spaces.service";
+
+
+describe('SpacesStatusService', () => {
+    let spectator: SpectatorService<SpacesStatusService>;
+    const createService = createServiceFactory({
+        service: SpacesStatusService,
+        providers: [
+            MockProvider(SpacesService, {
+                initialised: of(true),
+                list: of([])
+            })
+        ]
+    });
+
+    beforeEach(() => {
+        spectator = createService();
+    });
+
+    it('should create serice', () => {
+        expect(spectator.service).toBeInstanceOf(SpacesStatusService);
+    });
+})


### PR DESCRIPTION
… api

**Description of the change**

Replace staff-api polling calls with web socket subscription.
This change only covers free rooms in the landing page.

**Benefits**

Faster loading of free rooms in landing page

**Possible drawbacks**

The old staff-api implementation queries rooms that are free for the entire day. This change listens to changes to the `status` field of `System_id -> Bookings` which represents the room's free state at the moment.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using # or link directly) -->
- Fix for #235 

**Additional information**

implemented as according to document https://docs.google.com/document/d/168faoEL7MeqvzfER3sow0XmMuNn-WHTDFPvimn5NiF8

