### PR TITLE
fix(workplace): add restriction to end date in desk-form date-picker

### DIFF
--- a/apps/workplace/src/app/book/new-desk-flow/new-desk-form-details.component.ts
+++ b/apps/workplace/src/app/book/new-desk-flow/new-desk-form-details.component.ts
@@ -9,6 +9,7 @@ import { FormGroup } from '@angular/forms';
 import { BookingFormService } from '@placeos/bookings';
 import { AsyncHandler, SettingsService } from '@placeos/common';
 import { Desk, OrganisationService } from '@placeos/organisation';
+import { addDays, endOfDay } from 'date-fns';
 
 @Component({
     selector: 'new-desk-form-details',
@@ -90,7 +91,12 @@ import { Desk, OrganisationService } from '@placeos/organisation';
                     </div>
                     <div class="flex-1 min-w-[256px]">
                         <label for="date" i18n>Date<span>*</span></label>
-                        <a-date-field name="date" formControlName="date" i18n>
+                        <a-date-field
+                            name="date"
+                            formControlName="date"
+                            [to]="end_date"
+                            i18n
+                        >
                             Date and time must be in the future
                         </a-date-field>
                     </div>
@@ -265,6 +271,15 @@ export class NewDeskFormDetailsComponent extends AsyncHandler {
         return (
             this.allow_time_changes &&
             !!this._settings.get('app.desks.allow_all_day')
+        );
+    }
+
+    public get end_date() {
+        return endOfDay(
+            addDays(
+                Date.now(),
+                this._settings.get('app.desks.available_period') || 90
+            )
         );
     }
 


### PR DESCRIPTION
**Description of the change**

Update `new-desk-form-details` component in the new-desk-flow to apply an end date to the date picker in the desk booking form. The end date is the `app.desks.available_period` from Settings or the default value of 90 days.

**Benefits**

To apply the set available periods from Backoffice. 

**Possible drawbacks**

Unknown.

**Applicable issues**

- fixes #PPT-726

**Additional information**

N/A
