### PR TITLE
(asset-requests) fixed overlapping asset ids if duplicates are found

### DIFF
--- a/libs/assets/src/lib/assets.fn.ts
+++ b/libs/assets/src/lib/assets.fn.ts
@@ -425,6 +425,7 @@ export async function updateAssetRequestsForResource(
                                 const asset = group.assets.find(
                                     (_) => !used_ids.includes(_.id)
                                 );
+                                used_ids.push(asset.id);
                                 if (asset) return asset.id;
                                 throw new Error(
                                     'Unable to find available assets'


### PR DESCRIPTION
**Fix overlapping ids**

Fix overlapping ids when duplicates are found in the process of creating multiple assets request within the same event.

**Benefits**

Allows the user to book all the assets they need in case of making multiple asset requests in the same event for assets that only have a few items.

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

None
