### PR TITLE
fix(assets): prevent selecting end time for asset requests

### DIFF
--- a/libs/assets/src/lib/asset-select-modal/asset-filters.component.ts
+++ b/libs/assets/src/lib/asset-select-modal/asset-filters.component.ts
@@ -62,7 +62,7 @@ import {
                 "
                 [step]="step_interval"
                 [min]="min_offset"
-                [max]="max_offset"
+                [max]="max_offset - 1"
                 [use_24hr]="use_24hr"
             ></a-duration-field>
         </div>


### PR DESCRIPTION
From Will:
I would like to use this PR for:
1. Remove UI option to have asset delivery time same or after event end time (because front/backend fails to render those bookings properly).