### PR TITLE
feat(spaces): add ability to set alerts on rooms (PPT-1645)

### DIFF
--- a/apps/concierge/src/app/room-manager/room-alert-modal.component.ts
+++ b/apps/concierge/src/app/room-manager/room-alert-modal.component.ts
@@ -1,0 +1,107 @@
+import { Component, Inject } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { notifyError } from '@placeos/common';
+import { OrganisationService } from '@placeos/organisation';
+import { PlaceSystem, showMetadata, updateMetadata } from '@placeos/ts-client';
+
+@Component({
+    selector: 'room-alert-modal',
+    template: `
+        <header class="space-x-4">
+            <h2>Set Alert for {{ room.display_name || room.name }}</h2>
+            <button btn icon mat-dialog-close *ngIf="!loading">
+                <app-icon>close</app-icon>
+            </button>
+        </header>
+        <main
+            class="max-h-[65vh] overflow-y-auto overflow-x-hidden p-4 min-w-[24rem] flex flex-col"
+            *ngIf="!loading; else load_state"
+            [formGroup]="form"
+        >
+            <label for="status" i18n="@@statusLabel">Status</label>
+            <mat-form-field appearance="outline">
+                <mat-select name="status" formControlName="status">
+                    <mat-option value="">None</mat-option>
+                    <mat-option value="info">Info</mat-option>
+                    <mat-option value="warn">Warning</mat-option>
+                    <mat-option value="closed">Closed</mat-option>
+                </mat-select>
+            </mat-form-field>
+            <label for="message" i18n="@@messageLabel">Message</label>
+            <mat-form-field appearance="outline">
+                <textarea
+                    matInput
+                    name="message"
+                    formControlName="message"
+                ></textarea>
+            </mat-form-field>
+        </main>
+        <footer
+            class="p-2 flex justify-end border-t border-base-200"
+            *ngIf="!loading"
+        >
+            <button btn class="w-32" (click)="save()">Save</button>
+        </footer>
+        <ng-template #load_state>
+            <div class="flex flex-col items-center justify-center w-64 h-64">
+                <mat-spinner diameter="32"></mat-spinner>
+                <p class="mt-4">Saving room...</p>
+            </div>
+        </ng-template>
+    `,
+    styles: [``],
+})
+export class RoomAlertModalComponent {
+    public loading = false;
+    public readonly room: PlaceSystem = this._data.room;
+    public readonly form = new FormGroup({
+        status: new FormControl(''),
+        message: new FormControl(''),
+    });
+
+    constructor(
+        @Inject(MAT_DIALOG_DATA) private _data: { room: PlaceSystem },
+        private _dialog_ref: MatDialogRef<RoomAlertModalComponent>,
+        private _org: OrganisationService,
+    ) {
+        this.form.patchValue((this.room as any).alert || {});
+    }
+
+    public async save() {
+        this.loading = true;
+        const metadata = await showMetadata(
+            this._org.organisation.id,
+            'room_alerts',
+        )
+            .toPromise()
+            .catch((e) => {
+                notifyError(
+                    `Error loading existing room alert details: ${e.message || e}`,
+                );
+                this.loading = false;
+                throw e;
+            });
+        const alert = this.form.getRawValue();
+        if (alert.status === '') {
+            delete metadata.details[this.room.id];
+        } else {
+            metadata.details[this.room.id] = [alert.status, alert.message];
+        }
+        await updateMetadata(this._org.organisation.id, {
+            name: 'room_alerts',
+            details: metadata.details,
+            editors: metadata.editors || [],
+            description: 'Details for room alerts',
+        })
+            .toPromise()
+            .catch((e) => {
+                notifyError(
+                    `Error saving room alert details: ${e.message || e}`,
+                );
+                this.loading = false;
+                throw e;
+            });
+        this._dialog_ref.close(true);
+    }
+}

--- a/apps/concierge/src/app/room-manager/room-list.component.ts
+++ b/apps/concierge/src/app/room-manager/room-list.component.ts
@@ -33,10 +33,16 @@ import { notifySuccess, SettingsService } from '@placeos/common';
                         sortable: false,
                     },
                     {
+                        key: 'alert',
+                        name: 'Alert',
+                        size: '5.5rem',
+                        content: alert_template,
+                    },
+                    {
                         key: 'actions',
                         name: ' ',
                         content: action_template,
-                        size: '6.5rem',
+                        size: '3.5rem',
                         sortable: false,
                     },
                 ]"
@@ -69,22 +75,52 @@ import { notifySuccess, SettingsService } from '@placeos/common';
                 <app-icon>{{ data ? 'done' : 'close' }}</app-icon>
             </div>
         </ng-template>
+        <ng-template #alert_template let-data="data">
+            <div
+                [class.bg-warning]="data.status === 'warn'"
+                [class.bg-error]="data.status === 'closed'"
+                [class.bg-info]="data.status === 'info'"
+                *ngIf="data"
+                [matTooltip]="data.message"
+                class="rounded h-8 w-8 flex items-center justify-center text-2xl text-white mx-auto"
+            >
+                <app-icon>{{
+                    data.status === 'warn'
+                        ? 'warning'
+                        : data.status === 'info'
+                          ? 'info'
+                          : 'close'
+                }}</app-icon>
+            </div>
+        </ng-template>
         <ng-template #action_template let-row="row">
-            <div class="flex items-center space-x-2 p-2 mx-auto">
+            <div class="mx-auto">
                 <button
                     icon
                     matRipple
-                    matTooltip="Edit Room"
-                    (click)="editRoom(row)"
+                    class="h-12 w-12 rounded"
+                    [matMenuTriggerFor]="menu"
                 >
-                    <app-icon>edit</app-icon>
+                    <app-icon>more_vert</app-icon>
                 </button>
             </div>
-            <div class="flex items-center space-x-2 p-2 mx-auto">
+            <mat-menu #menu="matMenu">
+                <button mat-menu-item (click)="editRoom(row)">
+                    <div class="flex items-center space-x-2">
+                        <app-icon class="text-xl">edit</app-icon>
+                        <span>Edit Room</span>
+                    </div>
+                </button>
+                <button mat-menu-item (click)="setRoomAlert(row)">
+                    <div class="flex items-center space-x-2">
+                        <app-icon class="text-xl"
+                            >notification_important</app-icon
+                        >
+                        <span>Set Alert</span>
+                    </div>
+                </button>
                 <a
-                    icon
-                    matRipple
-                    matTooltip="View AV Control Panel"
+                    mat-menu-item
                     [href]="
                         row.support_url || control_path + row.id
                             | sanitize: 'url'
@@ -92,11 +128,16 @@ import { notifySuccess, SettingsService } from '@placeos/common';
                     target="_blank"
                     ref="noopener noreferrer"
                 >
-                    <app-icon className="material-symbols-rounded">
-                        tv_remote
-                    </app-icon>
+                    <div class="flex items-center space-x-2">
+                        <app-icon
+                            class="text-xl"
+                            className="material-symbols-rounded"
+                            >tv_remote</app-icon
+                        >
+                        <span>View Control Panel</span>
+                    </div>
                 </a>
-            </div>
+            </mat-menu>
         </ng-template>
     `,
     styles: [``],
@@ -105,6 +146,7 @@ export class RoomListComponent {
     public readonly rooms = this._manager.filtered_rooms;
 
     public readonly editRoom = (room) => this._manager.editRoom(room);
+    public readonly setRoomAlert = (room) => this._manager.setRoomAlert(room);
 
     public readonly copyToClipboard = (id: string) => {
         const success = this._clipboard.copy(id);

--- a/apps/concierge/src/app/room-manager/room-management.service.ts
+++ b/apps/concierge/src/app/room-manager/room-management.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { OrganisationService } from '@placeos/organisation';
-import { PlaceSystem, querySystems } from '@placeos/ts-client';
+import { PlaceSystem, querySystems, showMetadata } from '@placeos/ts-client';
 import { BehaviorSubject, combineLatest, of } from 'rxjs';
 import {
     catchError,
@@ -12,6 +12,7 @@ import {
 } from 'rxjs/operators';
 import { RoomModalComponent } from './room-modal.component';
 import { SettingsService } from '@placeos/common';
+import { RoomAlertModalComponent } from './room-alert-modal.component';
 
 export interface RoomListOptions {
     zones?: string[];
@@ -27,6 +28,15 @@ export class RoomManagementService {
 
     public options = this._options.asObservable();
 
+    public readonly room_alerts = combineLatest([
+        this._change,
+        this._org.active_building,
+    ]).pipe(
+        switchMap(() => showMetadata(this._org.organisation.id, 'room_alerts')),
+        map((_) => (_.details as Record<string, [string, string]>) || {}),
+        shareReplay(1),
+    );
+
     public readonly room_list = combineLatest([
         this._org.active_building,
         this._org.active_region,
@@ -34,22 +44,33 @@ export class RoomManagementService {
     ]).pipe(
         filter(([b, r]) => !!b?.id),
         switchMap(([bld, region]) =>
-            querySystems({
-                zone_id:
-                    (this._settings.get('app.use_region') ? region.id : '') ||
-                    bld.id,
-                limit: 2500,
-            }).pipe(
-                map(({ data }) => data),
-                catchError(() => of([]))
-            )
+            combineLatest([
+                querySystems({
+                    zone_id:
+                        (this._settings.get('app.use_region')
+                            ? region.id
+                            : '') || bld.id,
+                    limit: 2500,
+                }).pipe(
+                    map(({ data }) => data),
+                    catchError(() => of([])),
+                ),
+                this.room_alerts,
+            ]),
         ),
-        map((list) =>
-            list
+        map(([list, alerts]) => {
+            for (const id in alerts) {
+                const [status, message] = alerts[id];
+                list.find((_) => _.id === id).alert = {
+                    status,
+                    message,
+                };
+            }
+            return list
                 .filter((_) => this._org.levelWithID(_.zones as any))
-                .sort((a, b) => a.name.localeCompare(b.name))
-        ),
-        shareReplay(1)
+                .sort((a, b) => a.name.localeCompare(b.name));
+        }),
+        shareReplay(1),
     );
 
     public readonly filtered_rooms = combineLatest([
@@ -59,22 +80,22 @@ export class RoomManagementService {
         map(([list, options]) => {
             if (options.zones?.length) {
                 list = list.filter((_) =>
-                    options.zones.find((z) => _.zones.includes(z))
+                    options.zones.find((z) => _.zones.includes(z)),
                 );
             }
             if (options.search) {
                 list = list.filter((_) =>
-                    _.name.toLowerCase().includes(options.search.toLowerCase())
+                    _.name.toLowerCase().includes(options.search.toLowerCase()),
                 );
             }
             return list;
-        })
+        }),
     );
 
     constructor(
         private _org: OrganisationService,
         private _dialog: MatDialog,
-        private _settings: SettingsService
+        private _settings: SettingsService,
     ) {}
 
     public setFilters(options: Partial<RoomListOptions>) {
@@ -87,6 +108,16 @@ export class RoomManagementService {
 
     public editRoom(room: PlaceSystem = new PlaceSystem()) {
         const ref = this._dialog.open(RoomModalComponent, { data: { room } });
+        ref.afterClosed().subscribe((data) => {
+            if (data) setTimeout(() => this._change.next(Date.now()), 300);
+        });
+    }
+
+    public setRoomAlert(room: PlaceSystem) {
+        if (!room) return;
+        const ref = this._dialog.open(RoomAlertModalComponent, {
+            data: { room },
+        });
         ref.afterClosed().subscribe((data) => {
             if (data) setTimeout(() => this._change.next(Date.now()), 300);
         });

--- a/apps/concierge/src/app/room-manager/room-manager.module.ts
+++ b/apps/concierge/src/app/room-manager/room-manager.module.ts
@@ -14,6 +14,7 @@ import { RoomListComponent } from './room-list.component';
 import { RoomModalComponent } from './room-modal.component';
 import { MatChipsModule } from '@angular/material/chips';
 import { NewRoomManagerComponent } from './new-room-manager.component';
+import { RoomAlertModalComponent } from './room-alert-modal.component';
 
 const ROUTES: Route[] = [
     { path: '', component: RoomManagerComponent },
@@ -27,6 +28,7 @@ const ROUTES: Route[] = [
         RoomManagerTopbarComponent,
         RoomListComponent,
         RoomModalComponent,
+        RoomAlertModalComponent,
     ],
     imports: [
         CommonModule,

--- a/libs/events/src/lib/event-form.service.ts
+++ b/libs/events/src/lib/event-form.service.ts
@@ -178,6 +178,15 @@ export class EventFormService extends AsyncHandler {
         map((l) => unique(flatten(l.map((_) => _.features)))),
     );
 
+    public readonly room_alerts = this._changed.pipe(
+        switchMap((_) =>
+            showMetadata(this._org.organisation.id, 'room_alerts'),
+        ),
+        map((r) => r.details as Record<string, [string, string]>),
+        startWith({}),
+        shareReplay(1),
+    );
+
     public readonly filtered_spaces = combineLatest([
         this.spaces,
         this.options,

--- a/libs/spaces/src/lib/space-select-modal/new-space-select-modal.component.ts
+++ b/libs/spaces/src/lib/space-select-modal/new-space-select-modal.component.ts
@@ -69,7 +69,8 @@ import { Space } from '../space.class';
                 </div>
                 <space-details
                     [space]="displayed"
-                    class="h-full w-full sm:h-[65vh] absolute sm:relative flex sm:flex-col sm:max-w-[20rem] z-20 bg-base-100"
+                    [alert]="(room_alerts | async)[displayed?.id]"
+                    class="h-full w-full min-w-[20rem] sm:h-[65vh] absolute sm:relative flex sm:flex-col sm:max-w-[20rem] z-20 bg-base-100"
                     [class.hidden]="!displayed"
                     [class.inset-0]="displayed"
                     [hide_map]="view === 'map'"
@@ -165,6 +166,7 @@ export class NewSpaceSelectModalComponent {
     public selected: Space[] = [];
     public view = 'list';
     public readonly multiday = !!this._data.multiday;
+    public readonly room_alerts = this._event_form.room_alerts;
 
     public get selected_ids() {
         return this.selected.map((_) => _.id).join(',');
@@ -183,7 +185,7 @@ export class NewSpaceSelectModalComponent {
             spaces: Space[];
             options: Partial<EventFlowOptions>;
             multiday?: boolean;
-        }
+        },
     ) {
         this.selected = [...(_data.spaces || [])];
         this._event_form.setOptions(_data.options);
@@ -214,7 +216,7 @@ export class NewSpaceSelectModalComponent {
         } else {
             this._settings.saveUserSetting(
                 'favourite_spaces',
-                fav_list.filter((_) => _ !== item.id)
+                fav_list.filter((_) => _ !== item.id),
             );
         }
     }

--- a/libs/spaces/src/lib/space-select-modal/space-details.component.ts
+++ b/libs/spaces/src/lib/space-select-modal/space-details.component.ts
@@ -57,6 +57,18 @@ import { Space } from '../space.class';
                         {{ space.display_name || space.name }}
                     </h2>
                 </section>
+                <div
+                    class="my-2 px-2 py-1 text-xs rounded"
+                    *ngIf="alert"
+                    [class.bg-info]="alert[0] === 'info'"
+                    [class.text-info-content]="alert[0] === 'info'"
+                    [class.bg-warning]="alert[0] === 'warn'"
+                    [class.text-warning-content]="alert[0] === 'warn'"
+                    [class.bg-error]="alert[0] === 'closed'"
+                    [class.text-error-content]="alert[0] === 'closed'"
+                >
+                    {{ alert[1] }}
+                </div>
                 <hr />
                 <section details class="space-y-2">
                     <h2 class="text-xl font-medium" i18n>Details</h2>
@@ -162,6 +174,7 @@ export class SpaceDetailsComponent {
     @Input() public fav: boolean = false;
     @Input() public active: boolean = false;
     @Input() public hide_map: boolean = false;
+    @Input() public alert?: [string, string];
 
     @Output() public activeChange = new EventEmitter<boolean>();
     @Output() public close = new EventEmitter<void>();
@@ -176,7 +189,7 @@ export class SpaceDetailsComponent {
 
     public get building() {
         return this._org.buildings.find((_) =>
-            this.space?.zones.includes(_.id)
+            this.space?.zones.includes(_.id),
         );
     }
 

--- a/libs/spaces/src/lib/space-select-modal/space-list.component.ts
+++ b/libs/spaces/src/lib/space-select-modal/space-list.component.ts
@@ -21,12 +21,23 @@ import { Space } from '../space.class';
                     *ngFor="let space of available_spaces | async"
                     [class.!border-info]="active === space.id"
                     class="relative p-2 rounded-lg w-full shadow border bg-base-100 border-base-200"
+                    [class.!bg-error-light]="
+                        (room_alerts | async)[space.id]
+                            ? (room_alerts | async)[space.id][0] === 'closed'
+                            : false
+                    "
                 >
                     <button
                         matRipple
                         name="select-space"
-                        class="w-full h-full flex items-center"
+                        class="w-full h-full flex items-center rounded"
                         (click)="selectSpace(space)"
+                        [class.pointer-events-none]="
+                            (room_alerts | async)[space.id]
+                                ? (room_alerts | async)[space.id][0] ===
+                                  'closed'
+                                : false
+                        "
                     >
                         <div
                             class="relative min-w-[5rem] w-20 h-20 rounded-xl bg-base-200 mr-4 overflow-hidden flex items-center justify-center"
@@ -52,6 +63,48 @@ import { Space } from '../space.class';
                                     src="assets/icons/room-placeholder.svg"
                                 />
                             </ng-template>
+                            <div
+                                class="absolute bottom-1 left-1 rounded-full h-6 w-6 rotate-12 pointer-events-auto flex items-center justify-center"
+                                *ngIf="(room_alerts | async)[space.id]"
+                                [matTooltip]="
+                                    (room_alerts | async)[space.id][1]
+                                "
+                                [class.bg-error]="
+                                    (room_alerts | async)[space.id][0] ===
+                                    'closed'
+                                "
+                                [class.bg-info]="
+                                    (room_alerts | async)[space.id][0] ===
+                                    'info'
+                                "
+                                [class.bg-warning]="
+                                    (room_alerts | async)[space.id][0] ===
+                                    'warn'
+                                "
+                                [class.text-error-content]="
+                                    (room_alerts | async)[space.id][0] ===
+                                    'closed'
+                                "
+                                [class.text-info-content]="
+                                    (room_alerts | async)[space.id][0] ===
+                                    'info'
+                                "
+                                [class.text-warning-content]="
+                                    (room_alerts | async)[space.id][0] ===
+                                    'warn'
+                                "
+                                (click)="$event.stopPropagation()"
+                            >
+                                <app-icon>{{
+                                    (room_alerts | async)[space.id][0] ===
+                                    'warn'
+                                        ? 'warning'
+                                        : (room_alerts | async)[space.id][0] ===
+                                            'info'
+                                          ? 'info'
+                                          : 'close'
+                                }}</app-icon>
+                            </div>
                         </div>
                         <div class="space-y-2">
                             <div class="font-medium truncate mr-10">
@@ -139,10 +192,11 @@ export class SpaceListComponent {
     public readonly loading = this._event_form.loading;
 
     public readonly available_spaces = this._event_form.available_spaces;
+    public readonly room_alerts = this._event_form.room_alerts;
 
     constructor(
         private _event_form: EventFormService,
-        private _org: OrganisationService
+        private _org: OrganisationService,
     ) {}
 
     public level(zones: string[]) {


### PR DESCRIPTION
The ability to add alerts or user facing messages on bookable rooms that are shown at the time of booking, this might include equipment that has temporarily been removed or a total restriction on booking the room.

Concierge Room Manager: Add ability to create the alert.

WPA: Display the room alert per request above.