### PR TITLE
fix(uploads): report upload failures instead of reporting success

### DIFF
--- a/apps/signage-manager/src/app/signage.service.ts
+++ b/apps/signage-manager/src/app/signage.service.ts
@@ -123,6 +123,42 @@ function dataURLtoFile(data_url: string, filename: string) {
     return new File([uint8_array], filename, { type: mime_type });
 }
 
+/** Backoff between attempts at creating a media record, in milliseconds */
+const MEDIA_RETRY_DELAYS = [500, 1500, 4500];
+
+/**
+ * A 401 is deliberately absent: the API client already invalidates the token,
+ * re-authorises and replays the request itself, so retrying here as well would
+ * multiply into a long run of auth refreshes.
+ */
+function isRetryableMediaError(error: any) {
+    const status = error?.status;
+    // No status means the request never reached the server
+    if (typeof status !== 'number') return true;
+    return status === 408 || status === 429 || status >= 500;
+}
+
+async function retryMediaRequest<T>(request: () => Promise<T>): Promise<T> {
+    let last_error: unknown;
+    for (let attempt = 0; ; attempt++) {
+        try {
+            return await request();
+        } catch (error) {
+            last_error = error;
+            if (
+                !isRetryableMediaError(error) ||
+                attempt >= MEDIA_RETRY_DELAYS.length
+            ) {
+                break;
+            }
+            await new Promise((resolve) =>
+                setTimeout(resolve, MEDIA_RETRY_DELAYS[attempt]),
+            );
+        }
+    }
+    throw last_error;
+}
+
 interface PreparedUploadMedia {
     file: File;
     media_type: 'image' | 'video';
@@ -1641,13 +1677,34 @@ export class SignageService {
         };
     }
 
-    private _addSignageMedia(form_data: Partial<SignageMedia>) {
+    private async _addSignageMedia(form_data: Partial<SignageMedia>) {
         const group_id = this._api_group_id();
-        if (!group_id) return addSignageMedia(form_data);
-        return post(
-            `${apiEndpoint()}/signage/media?group_id=${encodeURIComponent(group_id)}`,
-            form_data,
-        ).then((resp: any) => new SignageMedia(resp));
+        const result = await retryMediaRequest(() =>
+            group_id
+                ? post(
+                      `${apiEndpoint()}/signage/media?group_id=${encodeURIComponent(group_id)}`,
+                      form_data,
+                  ).then((resp: any) => new SignageMedia(resp))
+                : addSignageMedia(form_data),
+        );
+        this._addMediaToList(result);
+        return result;
+    }
+
+    /**
+     * Fold a newly created item into the loaded media list. Refetching instead
+     * loses the item whenever the backend index lags the write, which reads as
+     * a failed upload.
+     */
+    private _addMediaToList(media: SignageMedia) {
+        if (!media?.id) return;
+        const item = decodeEntityNames(media);
+        this._media_items.update((items) =>
+            [item, ...items.filter((existing) => existing.id !== item.id)].sort(
+                (a, b) => b.created_at - a.created_at,
+            ),
+        );
+        this._media_tags.reload();
     }
 
     private _addSignagePlaylist(form_data: Partial<SignagePlaylist>) {
@@ -2147,7 +2204,6 @@ export class SignageService {
         prepared_file_metadata?: SignageMediaMetadata,
         plugin?: SignagePlugin,
     ) {
-        const is_new = !media.id;
         if (media.id) {
             if (
                 !this._requirePermission(
@@ -2220,7 +2276,6 @@ export class SignageService {
             },
         });
         await dialogClosed(ref);
-        if (is_new) setTimeout(() => this.changed(), 500);
     }
 
     private async _editMedia(id: string, data: any) {
@@ -2300,8 +2355,10 @@ export class SignageService {
             const media_list = await listSignagePlaylistMedia(playlist_id);
             const new_media_list = [...media_list.items, result.id];
             await this.updatePlaylistMedia(playlist_id, new_media_list);
+            // Only the playlist views need rebuilding; the media list already
+            // holds the item returned by the create call.
+            this.changed();
         }
-        this.changed();
         return result;
     }
 
@@ -2333,33 +2390,17 @@ export class SignageService {
             1280,
             720,
         ).catch(() => null);
+        // Resolves only once the upload is committed. Watching progress reach
+        // 100 is not enough: the last chunk lands before finalisation and the
+        // commit run, so a failure there would otherwise look like success.
         let media_id: string;
         if (upload_options) {
-            const upload = this._uploads.uploadFileWithProgress(
+            media_id = await this._uploads.uploadFileToCompletion(
                 upload_file,
                 false,
                 upload_options.permissions,
+                upload_options.on_progress,
             );
-            const details = await new Promise<ReturnType<typeof upload>>(
-                (resolve, reject) => {
-                    const interval = setInterval(() => {
-                        const state = upload();
-                        upload_options.on_progress?.(state.progress);
-                        if (state.error) {
-                            clearInterval(interval);
-                            reject(state.error);
-                            return;
-                        }
-                        if (state.progress < 100) return;
-                        clearInterval(interval);
-                        resolve(state);
-                    }, 100);
-                },
-            );
-            media_id = details.upload_id || details.upload?.id || details.id;
-            if (!media_id) {
-                throw new Error('Failed to get uploaded file ID');
-            }
         } else {
             media_id =
                 await this._uploads.uploadFileWithPermissionsToCompletion(

--- a/apps/signage-manager/src/tests/signage.service.spec.ts
+++ b/apps/signage-manager/src/tests/signage.service.spec.ts
@@ -249,6 +249,167 @@ describe('SignageService media uploads', () => {
         });
     });
 
+    it('waits for the upload to commit before creating the media record', async () => {
+        const service = createService();
+        let settle_upload: (id: string) => void;
+        const progress: number[] = [];
+        uploads.uploadFileToCompletion.mockImplementation(
+            (_file, _pub, _permissions, on_progress) => {
+                // Report a completed transfer, but do not resolve: the commit
+                // has not happened yet.
+                on_progress?.(100);
+                return new Promise<string>((resolve) => {
+                    settle_upload = resolve;
+                });
+            },
+        );
+
+        const pending = service.addMedia(
+            new File(['image'], 'poster.png', { type: 'image/png' }),
+            new SignageMedia({ name: 'Poster' }),
+            { is_landscape: true, duration: 0, width: 1920, height: 1080 },
+            { permissions: 'none', on_progress: (p) => progress.push(p) },
+        );
+        // Let the file validation and thumbnail steps settle
+        for (
+            let i = 0;
+            i < 20 && !uploads.uploadFileToCompletion.mock.calls.length;
+            i++
+        ) {
+            await new Promise((resolve) => setTimeout(resolve));
+        }
+
+        expect(progress).toContain(100);
+        expect(addSignageMedia).not.toHaveBeenCalled();
+
+        settle_upload('media-upload-1');
+        await pending;
+
+        expect(addSignageMedia).toHaveBeenCalled();
+    });
+
+    it('reports a commit failure instead of creating the media record', async () => {
+        const service = createService();
+        uploads.uploadFileToCompletion.mockRejectedValue(
+            new Error('Committing upload up-1 failed with status 401'),
+        );
+
+        await expect(
+            service.addMedia(
+                new File(['image'], 'poster.png', { type: 'image/png' }),
+                new SignageMedia({ name: 'Poster' }),
+                { is_landscape: true, duration: 0, width: 1920, height: 1080 },
+                { permissions: 'none' },
+            ),
+        ).rejects.toThrow(/status 401/);
+
+        expect(addSignageMedia).not.toHaveBeenCalled();
+    });
+
+    it('adds the created media to the library from the create response', async () => {
+        const service = createService();
+        (addSignageMedia as any).mockResolvedValue(
+            new SignageMedia({
+                id: 'media-new',
+                name: 'Poster',
+                created_at: 200,
+            }),
+        );
+        const test_service = service as unknown as SignageServiceTestAccess;
+        test_service['_media_items'].set([
+            new SignageMedia({ id: 'media-old', name: 'Old', created_at: 100 }),
+        ]);
+
+        await service.addMedia(
+            new File(['image'], 'poster.png', { type: 'image/png' }),
+            new SignageMedia({ name: 'Poster' }),
+            { is_landscape: true, duration: 0, width: 1920, height: 1080 },
+        );
+
+        expect(service.media().map((item) => item.id)).toEqual([
+            'media-new',
+            'media-old',
+        ]);
+    });
+
+    describe('creating the media record', () => {
+        const addMediaFor = (service: SignageService) =>
+            service.addMedia(
+                new File(['image'], 'poster.png', { type: 'image/png' }),
+                new SignageMedia({ name: 'Poster' }),
+                { is_landscape: true, duration: 0, width: 1920, height: 1080 },
+            );
+
+        it('retries a server error and then succeeds', async () => {
+            vi.useFakeTimers();
+            const service = createService();
+            (addSignageMedia as any)
+                .mockRejectedValueOnce({ status: 500 })
+                .mockRejectedValueOnce({ status: 503 })
+                .mockResolvedValueOnce(
+                    new SignageMedia({ id: 'media-retried' }),
+                );
+
+            const pending = addMediaFor(service);
+            await vi.runAllTimersAsync();
+            const result = await pending;
+
+            expect(addSignageMedia).toHaveBeenCalledTimes(3);
+            expect(result.id).toBe('media-retried');
+            vi.useRealTimers();
+        });
+
+        it('retries a transport failure with no status', async () => {
+            vi.useFakeTimers();
+            const service = createService();
+            (addSignageMedia as any)
+                .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+                .mockResolvedValueOnce(new SignageMedia({ id: 'media-net' }));
+
+            const pending = addMediaFor(service);
+            await vi.runAllTimersAsync();
+            await pending;
+
+            expect(addSignageMedia).toHaveBeenCalledTimes(2);
+            vi.useRealTimers();
+        });
+
+        it('gives up after exhausting the retries', async () => {
+            vi.useFakeTimers();
+            const service = createService();
+            (addSignageMedia as any).mockRejectedValue({ status: 500 });
+
+            const pending = addMediaFor(service);
+            pending.catch(() => null);
+            await vi.runAllTimersAsync();
+
+            await expect(pending).rejects.toMatchObject({ status: 500 });
+            // Initial attempt plus one per backoff delay
+            expect(addSignageMedia).toHaveBeenCalledTimes(4);
+            vi.useRealTimers();
+        });
+
+        it('does not retry a client error', async () => {
+            const service = createService();
+            (addSignageMedia as any).mockRejectedValue({ status: 422 });
+
+            await expect(addMediaFor(service)).rejects.toMatchObject({
+                status: 422,
+            });
+            expect(addSignageMedia).toHaveBeenCalledTimes(1);
+        });
+
+        it('leaves a 401 to the api client rather than retrying again', async () => {
+            const service = createService();
+            (addSignageMedia as any).mockRejectedValue({ status: 401 });
+
+            await expect(addMediaFor(service)).rejects.toMatchObject({
+                status: 401,
+            });
+            expect(addSignageMedia).toHaveBeenCalledTimes(1);
+        });
+    });
+
     it('updates the displayed media item after editing it', async () => {
         const media = new SignageMedia({ id: 'media-1', name: 'Old name' });
         const updated_media = new SignageMedia({

--- a/bun.lock
+++ b/bun.lock
@@ -54,7 +54,7 @@
         "@nx/playwright": "22.7.5",
         "@nx/web": "22.7.5",
         "@nx/workspace": "22.7.5",
-        "@placeos/cloud-uploads": "^1.1.1",
+        "@placeos/cloud-uploads": "^1.1.2",
         "@placeos/ts-client": "^5.2.0",
         "@playwright/test": "^1.49.0",
         "@schematics/angular": "22.0.1",
@@ -1046,7 +1046,7 @@
 
     "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
 
-    "@placeos/cloud-uploads": ["@placeos/cloud-uploads@1.1.1", "", { "peerDependencies": { "rxjs": "^7.8.2", "ts-md5": "^2.0.1" } }, "sha512-krF2RiuX4u0MkHBhm+DkrxWa91pMHmiWs3M4tuFpFDEsnrpbvPVvVPDs1EwqyLib5D6d/vxS6an+TcMTGfA+tg=="],
+    "@placeos/cloud-uploads": ["@placeos/cloud-uploads@1.1.2", "", { "peerDependencies": { "rxjs": "^7.8.2", "ts-md5": "^2.0.1" } }, "sha512-78xC1IRsjSX5BPOeet/uhoHlcODIvI11aNQPOPDwJpHi6JVz5kuQUbL1XynsYIToYoVq915KN6dGsuCihZZ6Xw=="],
 
     "@placeos/ts-client": ["@placeos/ts-client@5.2.0", "", { "dependencies": { "byte-base64": "^1.1.0", "fast-sha256": "^1.3.0" }, "peerDependencies": { "date-fns": "^4.1.0", "node-fetch": "^3.2.0", "ts-md5": "^2.0.1", "websocket": "^1.0.34" } }, "sha512-JHJO/66KAuBsArsZ5NnLXeasPpGGMzyRsVLD2pozlA1K/Jh89cUQR4oq6G/B7AA2b5Sz2LvRpKmpCDi9Fhu+ng=="],
 

--- a/libs/common/src/lib/uploads.service.ts
+++ b/libs/common/src/lib/uploads.service.ts
@@ -13,7 +13,7 @@ import {
     initUploads,
     uploadFile,
 } from '@placeos/cloud-uploads';
-import { authorise, token } from '@placeos/ts-client';
+import { apiKey, authorise, token } from '@placeos/ts-client';
 import { AsyncHandler } from './async-handler.class';
 import { log } from './general';
 
@@ -41,6 +41,44 @@ export interface UploadDetails {
 }
 
 export type UploadPermissions = 'none' | 'support' | 'admin';
+
+/**
+ * Rejection raised when the user dismisses the upload permissions modal.
+ * Lets consumers skip error messaging for a deliberate cancellation.
+ */
+export class UploadCancelledError extends Error {
+    constructor() {
+        super('Upload cancelled');
+        this.name = 'UploadCancelledError';
+    }
+}
+
+/** Failure of an upload, carrying the details of the attempt that failed */
+export class UploadFailedError extends Error {
+    constructor(
+        message: string,
+        public readonly details?: UploadDetails,
+    ) {
+        super(message);
+        this.name = 'UploadFailedError';
+    }
+}
+
+/** How many times a failed upload is re-attempted before reporting failure */
+const UPLOAD_RETRY_ATTEMPTS = 3;
+
+function uploadStateError(state: { error?: string }) {
+    return state?.error || 'Upload failed';
+}
+
+/** Normalise whatever an upload failed with into a throwable error */
+function uploadFailure(details: any) {
+    if (details instanceof Error) return details;
+    return new UploadFailedError(
+        details?.error || 'Upload failed',
+        details as UploadDetails,
+    );
+}
 
 export const UPLOAD_PERMISSIONS_MODAL = new InjectionToken<Type<any>>(
     'UploadPermissionsModalComponent',
@@ -104,7 +142,7 @@ export class UploadsService extends AsyncHandler {
                 data: { file, is_public: default_public },
             });
             ref.afterClosed().subscribe(async (details) => {
-                if (!details) return reject();
+                if (!details) return reject(new UploadCancelledError());
                 const id = await this.uploadFile(
                     details.file,
                     details.is_public,
@@ -141,7 +179,7 @@ export class UploadsService extends AsyncHandler {
                 next: update_fn,
                 error: (details) => {
                     if (details?.id) update_fn(details);
-                    if (!resolved) reject(details);
+                    if (!resolved) reject(uploadFailure(details));
                 },
                 complete: () => this._updateUploadHistory(),
             });
@@ -152,8 +190,14 @@ export class UploadsService extends AsyncHandler {
         file: File,
         pub = false,
         permissions: UploadPermissions = 'none',
+        on_progress?: (progress: number) => void,
     ) {
-        const details = await this._uploadFileToDetails(file, pub, permissions);
+        const details = await this._uploadFileToDetails(
+            file,
+            pub,
+            permissions,
+            on_progress,
+        );
         const upload_id = details.upload_id || details.upload?.id || details.id;
         if (!upload_id) throw new Error('Failed to get uploaded file ID');
         return upload_id;
@@ -178,7 +222,7 @@ export class UploadsService extends AsyncHandler {
             });
             ref.afterClosed().subscribe((details) => {
                 if (!details) {
-                    reject(new Error('Upload cancelled'));
+                    reject(new UploadCancelledError());
                     return;
                 }
                 this.uploadFileToCompletion(
@@ -215,9 +259,13 @@ export class UploadsService extends AsyncHandler {
     }
 
     private _initUploads() {
+        const api_key = apiKey();
         initUploads({
             auto_start: true,
-            token: token(),
+            // token() returns the literal string "x-api-key" when the session
+            // is authenticated with an API key, which is not a usable bearer
+            // token; the uploads API needs the key in its own header.
+            ...(api_key ? { api_key } : { token: token() }),
             endpoint: '/api/engine/v2/uploads',
             worker_url: 'assets/md5_worker.js',
         });
@@ -228,7 +276,7 @@ export class UploadsService extends AsyncHandler {
     private _updateUploadToken() {
         // ponytail: shared promise so concurrent failed uploads trigger one refresh
         this._token_refresh ||= (async () => {
-            if (!token(false)) await authorise();
+            if (!apiKey() && !token(false)) await authorise();
             this._initUploads();
         })().finally(() => (this._token_refresh = null));
         return this._token_refresh;
@@ -265,8 +313,17 @@ export class UploadsService extends AsyncHandler {
                     size: file.size,
                     upload,
                 };
-                let retried = false;
-                upload.state.subscribe(async (state) => {
+                let attempts = 0;
+                let settled = false;
+                let subscription: { unsubscribe: () => void };
+                // The state is a BehaviorSubject, so this can run before
+                // `subscription` has been assigned.
+                const stop = () => {
+                    settled = true;
+                    Promise.resolve().then(() => subscription?.unsubscribe());
+                };
+                subscription = upload.state.subscribe(async (state) => {
+                    if (settled) return;
                     upload_details.upload_id = upload.id;
                     if ((upload as any).access_url || state.progress >= 100) {
                         const local_url = `${
@@ -279,19 +336,26 @@ export class UploadsService extends AsyncHandler {
                     upload_details.progress = state.progress;
                     observer.next(upload_details);
                     if (state.status === 'FAILED') {
-                        if (!retried) {
-                            // token likely expired mid-upload; refresh and resume
-                            retried = true;
+                        if (attempts < UPLOAD_RETRY_ATTEMPTS) {
+                            // Most often an expired credential; re-validate it
+                            // and resume from the parts already uploaded.
+                            attempts += 1;
                             await this._updateUploadToken();
+                            if (settled) return;
                             upload.resume();
                             return;
                         }
+                        stop();
                         observer.error({
                             ...upload_details,
-                            error: (state as any).error || 'Error',
+                            error: uploadStateError(state),
                         });
+                        return;
                     }
-                    if (state.status === 'COMPLETED') observer.complete();
+                    if (state.status === 'COMPLETED') {
+                        stop();
+                        observer.complete();
+                    }
                 });
                 observer.next(upload_details);
             })
@@ -302,14 +366,16 @@ export class UploadsService extends AsyncHandler {
         file: File,
         pub = false,
         permissions: UploadPermissions = 'none',
+        on_progress?: (progress: number) => void,
     ) {
         return new Promise<UploadDetails>((resolve, reject) => {
             let last_details: UploadDetails;
             this._uploadFile(file, pub, permissions, {
                 next: (details) => {
                     last_details = details;
+                    on_progress?.(details.progress);
                 },
-                error: reject,
+                error: (details) => reject(uploadFailure(details)),
                 complete: () => {
                     this._updateUploadHistory();
                     resolve(last_details);

--- a/libs/common/src/tests/uploads.service.spec.ts
+++ b/libs/common/src/tests/uploads.service.spec.ts
@@ -1,5 +1,8 @@
 import { MatDialog } from '@angular/material/dialog';
-import { createServiceFactory, SpectatorService } from '@ngneat/spectator/vitest';
+import {
+    createServiceFactory,
+    SpectatorService,
+} from '@ngneat/spectator/vitest';
 import { BehaviorSubject } from 'rxjs';
 
 import * as cloud_uploads from '@placeos/cloud-uploads';
@@ -31,6 +34,7 @@ describe('UploadsService', () => {
         vi.mocked(cloud_uploads.humanReadableByteCount).mockReturnValue('1 KB');
         vi.mocked(cloud_uploads.uploadFile).mockResolvedValue(mock_upload);
         vi.mocked(ts_client.token).mockReturnValue('valid-token');
+        vi.mocked(ts_client.apiKey).mockReturnValue('');
         vi.mocked(ts_client.authorise).mockResolvedValue('new-token' as any);
     });
 
@@ -59,18 +63,87 @@ describe('UploadsService', () => {
         expect(await promise).toBe('up-1');
     });
 
-    it('should only retry a failed upload once', async () => {
+    it('should retry a failed upload a few times before giving up', async () => {
+        const promise = spectator.service.uploadFileToCompletion(
+            new File([], 'test.png'),
+        );
+        promise.catch(() => null);
+        for (let attempt = 0; attempt < 3; attempt++) {
+            await flush();
+            state.next({ status: 'FAILED', progress: 10 });
+            await flush();
+            expect(mock_upload.resume).toHaveBeenCalledTimes(attempt + 1);
+        }
+        state.next({
+            status: 'FAILED',
+            progress: 10,
+            error: 'Committing upload up-1 failed with status 401',
+        });
+        await flush();
+        await expect(promise).rejects.toThrow(/status 401/);
+        // Exhausted, so no further resume attempts
+        expect(mock_upload.resume).toHaveBeenCalledTimes(3);
+    });
+
+    it('should report the reason an upload failed', async () => {
         const promise = spectator.service.uploadFileToCompletion(
             new File([], 'test.png'),
         );
         promise.catch(() => null);
         await flush();
-        state.next({ status: 'FAILED', progress: 10 });
+        for (let attempt = 0; attempt < 4; attempt++) {
+            state.next({
+                status: 'FAILED',
+                progress: 10,
+                error: 'Finalisation request failed with status 500',
+            });
+            await flush();
+        }
+        await expect(promise).rejects.toMatchObject({
+            name: 'UploadFailedError',
+            message: 'Finalisation request failed with status 500',
+        });
+    });
+
+    it('should stop listening to an upload once it completes', async () => {
+        const promise = spectator.service.uploadFileToCompletion(
+            new File([], 'test.png'),
+        );
         await flush();
-        expect(mock_upload.resume).toHaveBeenCalledTimes(1);
-        state.next({ status: 'FAILED', progress: 10 });
+        state.next({ status: 'COMPLETED', progress: 100 });
+        await promise;
         await flush();
-        await expect(promise).rejects.toMatchObject({ error: 'Error' });
-        expect(mock_upload.resume).toHaveBeenCalledTimes(1);
+        expect(state.observed).toBe(false);
+    });
+
+    describe('credentials', () => {
+        it('should send an api key when the session uses one', async () => {
+            vi.mocked(ts_client.apiKey).mockReturnValue('secret-key');
+            const promise = spectator.service.uploadFile(
+                new File([], 'test.png'),
+            );
+            await flush();
+            state.next({ status: 'COMPLETED', progress: 100 });
+            await promise;
+            expect(cloud_uploads.initUploads).toHaveBeenCalledWith(
+                expect.objectContaining({ api_key: 'secret-key' }),
+            );
+            // "x-api-key" is not a usable bearer token
+            expect(cloud_uploads.initUploads).not.toHaveBeenCalledWith(
+                expect.objectContaining({ token: expect.anything() }),
+            );
+        });
+
+        it('should not re-authorise when an api key is present', async () => {
+            vi.mocked(ts_client.apiKey).mockReturnValue('secret-key');
+            vi.mocked(ts_client.token).mockReturnValue('');
+            const promise = spectator.service.uploadFile(
+                new File([], 'test.png'),
+            );
+            await flush();
+            state.next({ status: 'COMPLETED', progress: 100 });
+            await promise;
+            expect(ts_client.authorise).not.toHaveBeenCalled();
+        });
     });
 });

--- a/libs/form-fields/src/lib/image-field.component.ts
+++ b/libs/form-fields/src/lib/image-field.component.ts
@@ -12,8 +12,10 @@ import { MatRippleModule } from '@angular/material/core';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import {
     AsyncHandler,
+    notifyError,
     notifyInfo,
     UPLOAD_PERMISSIONS_MODAL,
+    UploadCancelledError,
     UploadsService,
 } from '@placeos/common';
 import { AuthenticatedImageDirective } from 'libs/components/src/lib/authenticated-image.directive';
@@ -168,9 +170,20 @@ export class ImageFieldComponent
         if (!element?.files) return;
         const files: FileList = element.files;
         if (!files.length) return;
-        const id = await this._uploads.uploadFileWithPermissions(files[0]);
-        this.interval('update_status', () => this._updateUploadHistory(id));
-        this._file_input().nativeElement.value = '';
+        try {
+            const id = await this._uploads.uploadFileWithPermissions(files[0]);
+            this.interval('update_status', () => this._updateUploadHistory(id));
+        } catch (error) {
+            this.clearInterval('update_status');
+            this.progress.set(0);
+            if (!(error instanceof UploadCancelledError)) {
+                notifyError(
+                    `Failed to upload ${files[0].name}: ${error?.message || 'Unknown error'}`,
+                );
+            }
+        } finally {
+            this._file_input().nativeElement.value = '';
+        }
     }
 
     private async _updateUploadHistory(id: string) {

--- a/libs/form-fields/src/lib/image-list-field.component.ts
+++ b/libs/form-fields/src/lib/image-list-field.component.ts
@@ -22,9 +22,11 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import {
     AsyncHandler,
+    notifyError,
     notifyInfo,
     unique,
     UPLOAD_PERMISSIONS_MODAL,
+    UploadCancelledError,
     UploadsService,
 } from '@placeos/common';
 import { AuthenticatedImageDirective } from 'libs/components/src/lib/authenticated-image.directive';
@@ -354,13 +356,22 @@ export class ImageListFieldComponent
                 this.interval('update_status', () =>
                     this._updateUploadHistory(),
                 );
+                // Keep going after a failure so one bad file doesn't drop the rest
                 for (let i = 0; i < files.length; i++) {
-                    const id = await this._uploads.uploadFileWithPermissions(
-                        files[i],
-                    );
-                    this.upload_ids.set([...this.upload_ids(), id]);
-                    this._file_input().nativeElement.value = '';
+                    try {
+                        const id =
+                            await this._uploads.uploadFileWithPermissions(
+                                files[i],
+                            );
+                        this.upload_ids.set([...this.upload_ids(), id]);
+                    } catch (error) {
+                        if (error instanceof UploadCancelledError) continue;
+                        notifyError(
+                            `Failed to upload ${files[i].name}: ${error?.message || 'Unknown error'}`,
+                        );
+                    }
                 }
+                this._file_input().nativeElement.value = '';
             }
         }
     }

--- a/libs/form-fields/src/lib/rich-text-input.component.ts
+++ b/libs/form-fields/src/lib/rich-text-input.component.ts
@@ -14,7 +14,12 @@ import {
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { DomSanitizer } from '@angular/platform-browser';
-import { AsyncHandler, UploadsService } from '@placeos/common';
+import {
+    AsyncHandler,
+    notifyError,
+    UploadCancelledError,
+    UploadsService,
+} from '@placeos/common';
 import { IconComponent } from '@placeos/components';
 import { apiKey, token } from '@placeos/ts-client';
 
@@ -374,15 +379,23 @@ export class RichTextInputComponent
         file_input.onchange = () => {
             const file = file_input.files?.[0];
             if (!file) return;
-            this._uploads.uploadFile(file, true).then((upload_id) => {
-                if (!upload_id) return;
-                const link = `${location.origin}/api/engine/v2/uploads/${encodeURIComponent(upload_id)}/url`;
-                this._setAuth();
-                setTimeout(() => {
-                    this._insertUploadedFile(link, file, images_only);
-                    this._syncValue();
-                }, 100);
-            });
+            this._uploads
+                .uploadFile(file, true)
+                .then((upload_id) => {
+                    if (!upload_id) return;
+                    const link = `${location.origin}/api/engine/v2/uploads/${encodeURIComponent(upload_id)}/url`;
+                    this._setAuth();
+                    setTimeout(() => {
+                        this._insertUploadedFile(link, file, images_only);
+                        this._syncValue();
+                    }, 100);
+                })
+                .catch((error) => {
+                    if (error instanceof UploadCancelledError) return;
+                    notifyError(
+                        `Failed to upload ${file.name}: ${error?.message || 'Unknown error'}`,
+                    );
+                });
         };
     }
 

--- a/libs/form-fields/src/tests/image-field.component.spec.ts
+++ b/libs/form-fields/src/tests/image-field.component.spec.ts
@@ -1,9 +1,11 @@
 import { Clipboard } from '@angular/cdk/clipboard';
 import { createComponentFactory, Spectator } from '@ngneat/spectator/vitest';
 import { MockComponent, MockProvider } from 'ng-mocks';
+import { of } from 'rxjs';
 
-import { UploadsService } from '@placeos/common';
+import { UploadCancelledError, UploadsService } from '@placeos/common';
 import { mockDirective } from '@placeos/common/tests';
+import { setNotifyOutlet } from 'libs/common/src/lib/notifications';
 import { AuthenticatedImageDirective } from 'libs/components/src/lib/authenticated-image.directive';
 import { IconComponent } from 'libs/components/src/lib/icon.component';
 import { ImageFieldComponent } from '../lib/image-field.component';
@@ -64,5 +66,47 @@ describe('ImageFieldComponent', () => {
         expect(spectator.component.disabled()).toBe(false);
         spectator.component.setDisabledState(true);
         expect(spectator.component.disabled()).toBe(true);
+    });
+
+    describe('upload failures', () => {
+        // Fake notification outlet so notifyError() is observable; it runs for
+        // real one layer above this spy.
+        const notify_open = vi.fn(() => ({
+            onAction: () => of(),
+            dismiss: vi.fn(),
+        }));
+        const fileEvent = (...files: File[]) => ({ target: { files } }) as any;
+
+        beforeEach(() => {
+            notify_open.mockClear();
+            setNotifyOutlet({ open: notify_open } as any, true);
+        });
+
+        afterEach(() => setNotifyOutlet(null, true));
+
+        it('should report a failed upload rather than rejecting', async () => {
+            const uploads = spectator.inject(UploadsService);
+            vi.mocked(uploads.uploadFileWithPermissions).mockRejectedValueOnce(
+                new Error('Commit failed with status 401'),
+            );
+            await expect(
+                spectator.component.uploadImage(
+                    fileEvent(new File([], 'a.png')),
+                ),
+            ).resolves.toBeUndefined();
+            expect(notify_open).toHaveBeenCalled();
+            expect(spectator.component.progress()).toBe(0);
+        });
+
+        it('should stay silent when the user cancels the upload', async () => {
+            const uploads = spectator.inject(UploadsService);
+            vi.mocked(uploads.uploadFileWithPermissions).mockRejectedValueOnce(
+                new UploadCancelledError(),
+            );
+            await spectator.component.uploadImage(
+                fileEvent(new File([], 'a.png')),
+            );
+            expect(notify_open).not.toHaveBeenCalled();
+        });
     });
 });

--- a/libs/form-fields/src/tests/image-list-field.component.spec.ts
+++ b/libs/form-fields/src/tests/image-list-field.component.spec.ts
@@ -6,8 +6,9 @@ import { createComponentFactory, Spectator } from '@ngneat/spectator/vitest';
 import { MockComponent, MockProvider } from 'ng-mocks';
 import { of } from 'rxjs';
 
-import { UploadsService } from '@placeos/common';
+import { UploadCancelledError, UploadsService } from '@placeos/common';
 import { mockDirective } from '@placeos/common/tests';
+import { setNotifyOutlet } from 'libs/common/src/lib/notifications';
 import { AuthenticatedImageDirective } from 'libs/components/src/lib/authenticated-image.directive';
 import { IconComponent } from 'libs/components/src/lib/icon.component';
 import { ImageListFieldComponent } from '../lib/image-list-field.component';
@@ -93,6 +94,50 @@ describe('ImageListFieldComponent', () => {
         spectator.component.viewImage('view.png');
         expect(dialog.open).toHaveBeenCalledWith(expect.anything(), {
             data: 'view.png',
+        });
+    });
+
+    describe('upload failures', () => {
+        // Fake notification outlet so notifyError() is observable; it runs for
+        // real one layer above this spy.
+        const notify_open = vi.fn(() => ({
+            onAction: () => of(),
+            dismiss: vi.fn(),
+        }));
+        const fileEvent = (...files: File[]) => ({ target: { files } }) as any;
+
+        beforeEach(() => {
+            notify_open.mockClear();
+            setNotifyOutlet({ open: notify_open } as any, true);
+        });
+
+        afterEach(() => setNotifyOutlet(null, true));
+
+        it('should upload the remaining files after one fails', async () => {
+            const uploads = spectator.inject(UploadsService);
+            vi.mocked(uploads.uploadFileWithPermissions)
+                .mockRejectedValueOnce(
+                    new Error('Upload failed with status 500'),
+                )
+                .mockResolvedValueOnce('upload-2');
+            await spectator.component.uploadImages(
+                fileEvent(new File([], 'a.png'), new File([], 'b.png')),
+            );
+            expect(uploads.uploadFileWithPermissions).toHaveBeenCalledTimes(2);
+            expect(spectator.component.upload_ids()).toEqual(['upload-2']);
+            expect(notify_open).toHaveBeenCalledTimes(1);
+        });
+
+        it('should stay silent when the user cancels an upload', async () => {
+            const uploads = spectator.inject(UploadsService);
+            vi.mocked(uploads.uploadFileWithPermissions).mockRejectedValueOnce(
+                new UploadCancelledError(),
+            );
+            await spectator.component.uploadImages(
+                fileEvent(new File([], 'a.png')),
+            );
+            expect(spectator.component.upload_ids()).toEqual([]);
+            expect(notify_open).not.toHaveBeenCalled();
         });
     });
 });

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "@nx/playwright": "22.7.5",
         "@nx/web": "22.7.5",
         "@nx/workspace": "22.7.5",
-        "@placeos/cloud-uploads": "^1.1.1",
+        "@placeos/cloud-uploads": "^1.1.2",
         "@placeos/ts-client": "^5.2.0",
         "@playwright/test": "^1.49.0",
         "@schematics/angular": "22.0.1",


### PR DESCRIPTION
Uploads that failed could be reported as successful, leaving signage media records pointing at uploads that were never committed. There were two independent causes, and fixing either alone would have left a partial fix:

- @placeos/cloud-uploads never checked the commit response, so a rejected commit still reported COMPLETED. Fixed in 1.1.2 and picked up here.
- addMedia resolved as soon as progress reached 100, which happens before finalisation and the commit run, so a failure afterwards was never seen. It now waits for the upload to actually complete.

Credentials:

- send the API key in its own header when the session uses one. token() returns the literal string "x-api-key" in that mode, which is not a usable bearer token, so every upload from an API key session was rejected.

Retries:

- retry a failed upload three times, re-validating credentials between attempts, up from exactly once
- retry the media create on 5xx, 408, 429 and transport failures with backoff. 401 is deliberately left to the API client, which already invalidates the token, re-authorises and replays the request.

Reporting:

- surface the reason an upload failed rather than a generic "Error"
- reject with a real Error, and distinguish a cancelled permissions dialog from a genuine failure
- handle upload rejections in the image, image list and rich text fields, which previously had none and would surface as unhandled rejections

Media library:

- build the list from the create response instead of a delayed refetch that lost the new item whenever the backend index lagged the write, which itself read as a failed upload
