### PR TITLE
fix(bookings): keep user input entered while the booking form initialises

### DIFF
--- a/libs/bookings/src/lib/booking-form.service.ts
+++ b/libs/bookings/src/lib/booking-form.service.ts
@@ -314,9 +314,42 @@ export class BookingFormService extends AsyncHandler {
     private _asset_window = '';
     public readonly view = signal<BookingFlowView>('form');
 
+    /**
+     * Edits the user made while `newForm` was waiting on the current user,
+     * carried across the deferred re-entry so the reset does not discard them.
+     */
+    private _pending_user_edits: Partial<BookingFormValue> | null = null;
+
     /** Apply a partial patch to the booking form model. */
     private _patch(value: Partial<BookingFormValue>, _opts?: unknown) {
         this.model.update((m) => ({ ...m, ...value }));
+    }
+
+    /**
+     * The fields the user has actually edited, with their current values.
+     *
+     * Reads the signal-forms dirty flags rather than diffing against a
+     * default. Programmatic writes (`_patch`, `model.set`) do not mark a field
+     * dirty, so this returns genuine user input and nothing else — which is
+     * what makes it safe to replay over a freshly loaded booking.
+     */
+    private _userEditedValues(): Partial<BookingFormValue> {
+        const form = this.form as any;
+        if (!form) return {};
+        const model = untracked(this.model) as Record<string, any>;
+        const edits: Record<string, any> = {};
+        for (const key of Object.keys(model || {})) {
+            const field = form[key];
+            if (typeof field !== 'function') continue;
+            // A field can throw if the tree has no matching sub-field, which
+            // is not worth losing the rest of the user's input over.
+            try {
+                if (field()?.dirty?.()) edits[key] = model[key];
+            } catch {
+                continue;
+            }
+        }
+        return edits;
     }
 
     private _syncAssetOptions() {
@@ -783,9 +816,18 @@ export class BookingFormService extends AsyncHandler {
 
     public newForm(type: BookingType, booking: Booking = new Booking({})) {
         if (!currentUserIsLoaded()) {
-            currentUserLoaded().then(() => this.newForm(type, booking));
+            // The form is already rendered and interactive at this point, so
+            // anything typed or toggled before the user resolves would be
+            // destroyed by the reset below. Capture it on the way back in —
+            // as late as possible, so we take the user's final state.
+            currentUserLoaded().then(() => {
+                this._pending_user_edits = this._userEditedValues();
+                this.newForm(type, booking);
+            });
             return;
         }
+        const user_edits = this._pending_user_edits;
+        this._pending_user_edits = null;
         // Never apply an existing booking's edit state to a different type
         // (e.g. editing parking then opening the desk form).
         if (isCrossTypeEdit(booking, type)) booking = new Booking({});
@@ -822,6 +864,14 @@ export class BookingFormService extends AsyncHandler {
             ),
             { emitEvent: false },
         );
+        // Re-apply the user's own edits over the incoming booking. Done here,
+        // before `applyDurationSettings`, so a restored `all_day` still drives
+        // the time-sync window; and before `_syncWindowIfUnchanged`, which
+        // compares against `initial_date`/`initial_duration` and so leaves a
+        // user-changed window alone of its own accord.
+        if (user_edits && Object.keys(user_edits).length) {
+            this._patch(user_edits, { emitEvent: false });
+        }
         this.applyDurationSettings();
         this._syncAssetOptions();
         const form_change = effect(

--- a/libs/bookings/src/test/booking-form.service.spec.ts
+++ b/libs/bookings/src/test/booking-form.service.spec.ts
@@ -1717,13 +1717,13 @@ describe('BookingFormService', () => {
         ).mockResolvedValue(true);
         const saved_desks: string[] = [];
         vi.spyOn(spectator.service, 'postForm').mockImplementation(async () => {
-                const value = spectator.service.model();
-                saved_desks.push(value.asset_id);
-                return new Booking({
-                    id: `booking-${saved_desks.length}`,
-                    user_email: value.user_email,
-                    asset_id: value.asset_id,
-                });
+            const value = spectator.service.model();
+            saved_desks.push(value.asset_id);
+            return new Booking({
+                id: `booking-${saved_desks.length}`,
+                user_email: value.user_email,
+                asset_id: value.asset_id,
+            });
         });
         spectator.service.newForm(
             'desk',
@@ -1803,17 +1803,17 @@ describe('BookingFormService', () => {
             extension_name: string;
         }[] = [];
         vi.spyOn(spectator.service, 'postForm').mockImplementation(async () => {
-                const value = spectator.service.model();
-                saved_forms.push({
-                    asset_id: value.asset_id,
-                    resource_id: value.resources?.[0]?.id,
-                    extension_name: value.name,
-                });
-                return new Booking({
-                    id: `booking-${saved_forms.length}`,
-                    user_email: value.user_email,
-                    asset_id: value.asset_id,
-                });
+            const value = spectator.service.model();
+            saved_forms.push({
+                asset_id: value.asset_id,
+                resource_id: value.resources?.[0]?.id,
+                extension_name: value.name,
+            });
+            return new Booking({
+                id: `booking-${saved_forms.length}`,
+                user_email: value.user_email,
+                asset_id: value.asset_id,
+            });
         });
         spectator.service.newForm(
             'desk',
@@ -1897,14 +1897,14 @@ describe('BookingFormService', () => {
         ).mockResolvedValue(true);
         const child_parent_ids: string[] = [];
         vi.spyOn(spectator.service, 'postForm').mockImplementation(async () => {
-                const value = spectator.service.model();
-                child_parent_ids.push(value.parent_id);
-                return new Booking({
-                    id: `booking-child-${child_parent_ids.length}`,
-                    parent_id: value.parent_id,
-                    user_email: value.user_email,
-                    asset_id: value.asset_id,
-                });
+            const value = spectator.service.model();
+            child_parent_ids.push(value.parent_id);
+            return new Booking({
+                id: `booking-child-${child_parent_ids.length}`,
+                parent_id: value.parent_id,
+                user_email: value.user_email,
+                asset_id: value.asset_id,
+            });
         });
         spectator.service.newForm(
             'desk',
@@ -1998,17 +1998,17 @@ describe('BookingFormService', () => {
         ).mockResolvedValue(true);
         const saved_users: string[] = [];
         vi.spyOn(spectator.service, 'postForm').mockImplementation(async () => {
-                const value = spectator.service.model();
-                saved_users.push(value.user_email);
-                if (value.user_email === 'member.one@example.com') {
-                    throw new Error('Save failed');
-                }
-                return new Booking({
-                    id: `booking-child-${saved_users.length}`,
-                    parent_id: value.parent_id,
-                    user_email: value.user_email,
-                    asset_id: value.asset_id,
-                });
+            const value = spectator.service.model();
+            saved_users.push(value.user_email);
+            if (value.user_email === 'member.one@example.com') {
+                throw new Error('Save failed');
+            }
+            return new Booking({
+                id: `booking-child-${saved_users.length}`,
+                parent_id: value.parent_id,
+                user_email: value.user_email,
+                asset_id: value.asset_id,
+            });
         });
         spectator.service.newForm(
             'desk',
@@ -2114,13 +2114,13 @@ describe('BookingFormService', () => {
         ).mockResolvedValue(true);
         const saved_names: string[] = [];
         vi.spyOn(spectator.service, 'postForm').mockImplementation(async () => {
-                const value = spectator.service.model();
-                saved_names.push(value.asset_name);
-                return new Booking({
-                    id: `booking-${saved_names.length}`,
-                    user_email: value.user_email,
-                    asset_id: value.asset_id,
-                });
+            const value = spectator.service.model();
+            saved_names.push(value.asset_name);
+            return new Booking({
+                id: `booking-${saved_names.length}`,
+                user_email: value.user_email,
+                asset_id: value.asset_id,
+            });
         });
         spectator.service.newForm(
             'desk',
@@ -2199,16 +2199,16 @@ describe('BookingFormService', () => {
         ).mockResolvedValue([all_desks[2]]);
         const saved_forms: { user_email: string; asset_id: string }[] = [];
         vi.spyOn(spectator.service, 'postForm').mockImplementation(async () => {
-                const value = spectator.service.model();
-                saved_forms.push({
-                    user_email: value.user_email,
-                    asset_id: value.asset_id,
-                });
-                return new Booking({
-                    id: `booking-${saved_forms.length}`,
-                    user_email: value.user_email,
-                    asset_id: value.asset_id,
-                });
+            const value = spectator.service.model();
+            saved_forms.push({
+                user_email: value.user_email,
+                asset_id: value.asset_id,
+            });
+            return new Booking({
+                id: `booking-${saved_forms.length}`,
+                user_email: value.user_email,
+                asset_id: value.asset_id,
+            });
         });
         spectator.service.newForm(
             'desk',
@@ -2306,14 +2306,14 @@ describe('BookingFormService', () => {
         ).mockResolvedValue([all_desks[1]]);
         const saved_forms: { id: string; parent_id: string }[] = [];
         vi.spyOn(spectator.service, 'postForm').mockImplementation(async () => {
-                const value = spectator.service.model();
-                saved_forms.push({ id: value.id, parent_id: value.parent_id });
-                return new Booking({
-                    id: value.id || `booking-child-${saved_forms.length}`,
-                    parent_id: value.parent_id,
-                    user_email: value.user_email,
-                    asset_id: value.asset_id,
-                });
+            const value = spectator.service.model();
+            saved_forms.push({ id: value.id, parent_id: value.parent_id });
+            return new Booking({
+                id: value.id || `booking-child-${saved_forms.length}`,
+                parent_id: value.parent_id,
+                user_email: value.user_email,
+                asset_id: value.asset_id,
+            });
         });
         spectator.service.newForm(
             'desk',
@@ -2452,14 +2452,14 @@ describe('BookingFormService', () => {
         ];
         let booking_count = 0;
         vi.spyOn(spectator.service, 'postForm').mockImplementation(async () => {
-                const value = spectator.service.model();
-                booking_count++;
-                return new Booking({
-                    id: `booking-${booking_count}`,
-                    user_email: value.user_email,
-                    asset_id: value.asset_id,
-                    extension_data: { group_members: group_members_payload },
-                });
+            const value = spectator.service.model();
+            booking_count++;
+            return new Booking({
+                id: `booking-${booking_count}`,
+                user_email: value.user_email,
+                asset_id: value.asset_id,
+                extension_data: { group_members: group_members_payload },
+            });
         });
         spectator.service.newForm(
             'desk',
@@ -2882,5 +2882,115 @@ describe('BookingFormService', () => {
 
         expect(savedBookings().length).toBe(1);
         expect((savedBookings()[0] as Booking).asset_ids).toEqual(['desk-2']);
+    });
+
+    describe('initialisation while the user is still loading', () => {
+        /**
+         * Put the service into the state `newForm` sees on a slow load: no
+         * current user yet, so it defers and returns while the form is already
+         * rendered and interactive.
+         *
+         * Nothing is mocked. `currentUserIsLoaded()` is real, and it reports
+         * "loaded" whenever it detects a test runtime, so the runtime probe
+         * (`typeof vi`) is what has to be neutralised to reach the branch.
+         * That keeps the real promise plumbing in `currentUserLoaded()` under
+         * test rather than a stub of it.
+         */
+        function deferCurrentUser() {
+            const runtime_vi = (globalThis as any).vi;
+            setCurrentUser(new StaffUser({}));
+            (globalThis as any).vi = undefined;
+            const restore = () => ((globalThis as any).vi = runtime_vi);
+            return {
+                restore,
+                release: async () => {
+                    restore();
+                    setCurrentUser(
+                        new StaffUser({
+                            id: 'current-user',
+                            email: 'current.user@example.com',
+                            name: 'Current User',
+                        }),
+                    );
+                    // let the `.then` re-entry and its patches settle
+                    await Promise.resolve();
+                    await Promise.resolve();
+                    await Promise.resolve();
+                },
+            };
+        }
+
+        /** Type into a field the way the Field directive does. */
+        function userEdits(field: string, value: any) {
+            const node = (spectator.service.form as any)[field]();
+            node.value.set(value);
+            node.markAsDirty();
+        }
+
+        it('keeps input the user entered before initialisation finished', async () => {
+            const deferred = deferCurrentUser();
+            try {
+                spectator.service.newForm('desk');
+
+                userEdits('title', 'Quiet corner desk');
+                userEdits('all_day', true);
+
+                await deferred.release();
+
+                expect(spectator.service.model().title).toBe(
+                    'Quiet corner desk',
+                );
+                expect(spectator.service.model().all_day).toBe(true);
+            } finally {
+                deferred.restore();
+            }
+        });
+
+        it('does not resurrect that input on the next new form', async () => {
+            // The preserved edits are one-shot. If they leaked, opening a
+            // second form would silently inherit the previous booking's title.
+            const deferred = deferCurrentUser();
+            try {
+                spectator.service.newForm('desk');
+                userEdits('title', 'Quiet corner desk');
+                await deferred.release();
+            } finally {
+                deferred.restore();
+            }
+
+            spectator.service.newForm('desk');
+
+            expect(spectator.service.model().title).not.toBe(
+                'Quiet corner desk',
+            );
+        });
+
+        it('leaves untouched fields to the incoming booking', async () => {
+            // Only dirty fields are carried across. A field the user never
+            // touched must still take its value from the booking being opened.
+            const deferred = deferCurrentUser();
+            try {
+                spectator.service.newForm(
+                    'desk',
+                    new Booking({
+                        id: 'bkn-1',
+                        booking_type: 'desk',
+                        title: 'From the booking',
+                        asset_id: 'desk-1',
+                    }),
+                );
+
+                userEdits('all_day', true);
+
+                await deferred.release();
+
+                expect(spectator.service.model().all_day).toBe(true);
+                expect(spectator.service.model().title).toBe(
+                    'From the booking',
+                );
+            } finally {
+                deferred.restore();
+            }
+        });
     });
 });


### PR DESCRIPTION
Fixes [PPT-2643](https://acaprojects.atlassian.net/browse/PPT-2643).

## The bug

`BookingFormService.newForm()` defers itself until the current user has loaded:

```ts
if (!currentUserIsLoaded()) {
    currentUserLoaded().then(() => this.newForm(type, booking));
    return;   // <- returns; the form is already rendered and interactive
}
...
this.model.set(bookingFormValue(new Booking()));   // <- wipes
this.form().reset();                               // <- wipes
```

The form accepts input during that window. When initialisation completes it resets, silently discarding whatever was entered: title reverts to the default `Booking`, All Day switches back off, Require locker switches back on.

On a fast connection nobody notices because init finishes first. On a slow one you start typing a title and it vanishes a second later. It affects every flow through this shared service, so desk, locker, parking, visitor and room, across workplace and the other booking UIs.

## The fix

Option A from the ticket: preserve the input rather than gate interactivity.

The user's edits are captured on the way back into `newForm` and replayed over the incoming booking. Only fields the user actually touched are carried, read from the signal-forms `dirty` flags, so programmatic writes (`_patch`, `model.set`) are ignored and a field the user never touched still takes its value from the booking being opened.

Placement matters and is commented in the source. The replay happens after the main patch but before `applyDurationSettings()`, so a restored `all_day` still drives the time-sync window, and before `_syncWindowIfUnchanged()`, which compares against the initial window and so yields to a user-changed one without any extra handling.

The capture is set synchronously immediately before the re-entry, so there is no window in which a normal `newForm` call could consume edits meant for a deferred one.

I did not take Option B (gating interactivity behind a loader) because it is a visible UX change across every booking flow and is yours to call.

## Testing

Three specs in `booking-form.service.spec.ts` under `initialisation while the user is still loading`.

No mocking. `currentUserIsLoaded()` reports "loaded" whenever it detects a test runtime, so the tests neutralise that runtime probe to reach the deferred branch, which keeps the real promise plumbing in `currentUserLoaded()` under test rather than a stub of it.

Red-checked against unfixed code, where two of the three fail with exactly the ticket's symptoms:

```
AssertionError: expected 'Booking' to be 'Quiet corner desk'
AssertionError: expected false to be true
```

The third (`does not resurrect that input on the next new form`) passes either way by design. It guards against the new code leaking preserved edits into a later form rather than reproducing the original bug.

- `nx test bookings` — 393 passed
- `nx affected -t test` — 25 projects, all passed
- `nx affected -t build` — 16 projects, all built

`nx lint` fails in this workspace on untouched libraries too (`Failed to load config "plugin:@angular-eslint/recommended"`), so it is pre-existing and unrelated.

## Follow-up

The workplace e2e suite currently works around this bug in `bookDeskViaUI` with a converging retry block, which means it no longer detects it. Once this merges that workaround should come out and be replaced with a spec asserting input survives initialisation. That lives on the e2e branches (#476/#477) and is not touched here.

How it was found: the new e2e suite, which produced bookings saved under the wrong title locally and an unopenable confirm dialog in CI (a reverted All Day leaves the default 5-minute slot, which on a slow run has already passed and invalidates the form).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PPT-2643]: https://acaprojects.atlassian.net/browse/PPT-2643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ