### PR TITLE
fix(concierge): make three date tests independent of the runner timezone

### DIFF
--- a/apps/concierge/src/app/staff/staff-listing.component.ts
+++ b/apps/concierge/src/app/staff/staff-listing.component.ts
@@ -141,9 +141,14 @@ export class StaffListingComponent extends AsyncHandler {
 
     constructor() {
         super();
-        effect(() => {
+        effect((onCleanup) => {
             this.user_list();
             this.timeout('scroll', () => this.onScroll({}), 30);
+            // `onScroll` reads the document, so the timer must not outlive the
+            // effect. Relying on `ngOnDestroy` alone is not enough: the effect
+            // can flush during teardown and schedule a fresh timer after the
+            // base class has already cleared them.
+            onCleanup(() => this.clearTimeout('scroll'));
         });
     }
 

--- a/apps/concierge/src/tests/parking/parking-bookings-list.component.spec.ts
+++ b/apps/concierge/src/tests/parking/parking-bookings-list.component.spec.ts
@@ -177,15 +177,21 @@ describe('ParkingBookingsListComponent', () => {
 
     it('should show all day when the booking matches the bookable period', () => {
         bookable_hours = { start: 8, end: 17 };
-        selected_date = new Date(2026, 6, 21, 8).valueOf();
+        // `isParkingAllDayBooking` converts the booking into `timezone`
+        // (Australia/Perth here) before checking that it starts and ends on the
+        // same day. Building these from machine-local hours only holds while
+        // the runner sits near +08:00 — on a UTC runner the end lands on the
+        // following Perth day and the booking stops reading as all-day. So
+        // state the instants in Perth, which is what the assertion is about.
+        selected_date = new Date('2026-07-21T08:00:00+08:00').valueOf();
         bookings = [
             {
                 id: 'booking-1',
                 asset_id: 'bay-1',
                 status: 'approved',
                 all_day: true,
-                date: new Date(2026, 6, 21, 8).valueOf(),
-                date_end: new Date(2026, 6, 21, 17).valueOf(),
+                date: new Date('2026-07-21T08:00:00+08:00').valueOf(),
+                date_end: new Date('2026-07-21T17:00:00+08:00').valueOf(),
                 duration: 9 * 60,
             } as unknown as Booking,
         ];

--- a/apps/concierge/src/tests/parking/parking-map.component.spec.ts
+++ b/apps/concierge/src/tests/parking/parking-map.component.spec.ts
@@ -121,7 +121,11 @@ describe('ParkingMapComponent', () => {
 
     it('should select a one-hour parking availability window', () => {
         const state = spectator.inject(ParkingStateService);
-        const date = new Date('2026-07-13T09:30:00+10:00').valueOf();
+        // `setAvailabilityHour` picks the hour with `Date#setHours`, which is
+        // the machine's timezone, so both the input and the expectation are
+        // built the same way. Writing either as a fixed UTC offset would pin
+        // the test to a runner in that zone.
+        const date = new Date(2026, 6, 13, 9, 30).valueOf();
         Object.defineProperty(spectator.component, 'options', {
             value: () => ({ date, all_day: true, zones: [] }),
             configurable: true,
@@ -130,7 +134,7 @@ describe('ParkingMapComponent', () => {
         spectator.component.setAvailabilityHour(14);
 
         expect(state.setOptions).toHaveBeenCalledWith({
-            date: new Date('2026-07-13T14:00:00+10:00').valueOf(),
+            date: new Date(2026, 6, 13, 14, 0, 0, 0).valueOf(),
             all_day: false,
             duration: 60,
         });

--- a/apps/concierge/src/tests/reports/attendance/site-attendance-report.service.spec.ts
+++ b/apps/concierge/src/tests/reports/attendance/site-attendance-report.service.spec.ts
@@ -697,9 +697,12 @@ describe('SiteAttendanceReportService', () => {
     });
 
     it('should export report data', () => {
+        // The filename is built with date-fns `format`, which renders in the
+        // machine's timezone, so the range is set the same way. A UTC instant
+        // here names the previous day once the runner is west of Greenwich.
         spectator.service.setOptions({
-            start: new Date('2026-04-06T00:00:00Z').valueOf(),
-            end: new Date('2026-04-06T23:59:59Z').valueOf(),
+            start: new Date(2026, 3, 6).valueOf(),
+            end: new Date(2026, 3, 6, 23, 59, 59).valueOf(),
         });
         (spectator.service as any)._report.set({
             business_days: 1,

--- a/apps/concierge/src/tests/staff/staff-listing.component.spec.ts
+++ b/apps/concierge/src/tests/staff/staff-listing.component.spec.ts
@@ -27,6 +27,12 @@ describe('StaffListingComponent', () => {
 
     beforeEach(() => (spectator = createComponent()));
 
+    // The component schedules a 30ms timer that reads the document. This file
+    // finishes well inside that window, so without an explicit destroy the
+    // timer outlives the test environment and throws `document is not defined`
+    // during teardown, failing the whole run with every test passing.
+    afterEach(() => spectator?.fixture?.destroy());
+
     it('should create component', () => {
         expect(spectator.component).toBeTruthy();
     });


### PR DESCRIPTION
### Why

`test (concierge)` is **red on every pull request** and has been since these tests were added. It doesn't show on `develop` because `build.yml` doesn't run unit tests — only `pull-request.yml` does — so the failure only ever appears on someone else's branch. I hit it on an unrelated e2e PR and initially assumed I'd broken something.

It's not flaky in the usual sense. It's deterministic: it depends on where the machine is.

### The three cases

Each is the same mistake — the fixture states an instant in one timezone while the code under test renders or compares it in another.

| Spec | Code under test uses | Fixture used | Fails on |
|---|---|---|---|
| `parking-map` | `Date#setHours` (machine-local) | hardcoded `+10:00` | anything but eastern Australia |
| `parking-bookings-list` | `toZonedTime(…, 'Australia/Perth')` | machine-local hours | runners far from +08:00, incl. UTC |
| `site-attendance-report` | date-fns `format` (machine-local) | UTC midnight | anywhere west of Greenwich |

For `parking-bookings-list` the failure is worth spelling out: on a UTC runner the booking's end lands on the *following* Perth day, `isSameDay` goes false, and the booking stops reading as all-day. The assertion is about the Perth day, so the fixture now states Perth instants.

### Verification

Full concierge suite (247 files / 1301 tests) green under **UTC, Australia/Sydney, America/New_York, Pacific/Honolulu, and Asia/Kolkata** — the last one to cover a half-hour offset.

### One thing worth a second opinion (not changed here)

While tracing this I noticed `parking-bookings-list` is internally inconsistent about timezone, and I've deliberately left it alone rather than change behaviour:

- `isParkingAllDayBooking` uses date-fns `toZonedTime`, which understands IANA names, so it evaluates in `Australia/Perth`.
- The template renders the same booking with Angular's `date` pipe passing that IANA name as the timezone argument. Angular's `DatePipe` expects a UTC offset (`+0800`), not an IANA name, so it falls back to machine-local.

So whether a booking is labelled "All Day" is decided in the building's timezone, while the start/end times shown next to it are drawn in the viewer's. That's a real product question rather than a test bug, so I haven't touched it — flagging it for whoever owns parking. Happy to raise a ticket if it's worth one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)