### PR TITLE
fix(explore): make the parking clamp test independent of the runner timezone

### DIFF
--- a/libs/explore/src/tests/explore-parking.service.spec.ts
+++ b/libs/explore/src/tests/explore-parking.service.spec.ts
@@ -146,7 +146,12 @@ describe('ExploreParkingService', () => {
     });
 
     it('should clamp all-day parking queries to bookable hours', async () => {
-        const date = new Date('2026-07-09T13:45:00+10:00').valueOf();
+        // The clamp applies `bookable_hours` with `Date#setHours`, which is the
+        // machine's timezone, so the input and the expectations below are all
+        // built from local components. Writing them as a fixed UTC offset pins
+        // the test to a runner in that zone — on a UTC runner the expected
+        // start came out ten hours adrift.
+        const date = new Date(2026, 6, 9, 13, 45).valueOf();
         const settings = spectator.inject(SettingsService);
         vi.mocked(settings.get).mockImplementation((key) =>
             key === 'app.parking.bookable_hours'
@@ -167,10 +172,10 @@ describe('ExploreParkingService', () => {
             );
         const params = (call[0] as any).query_params;
         expect(params.period_start).toBe(
-            getUnixTime(new Date('2026-07-09T08:00:00+10:00')),
+            getUnixTime(new Date(2026, 6, 9, 8, 0, 0, 0)),
         );
         expect(params.period_end).toBe(
-            getUnixTime(new Date('2026-07-09T18:00:00+10:00')),
+            getUnixTime(new Date(2026, 6, 9, 18, 0, 0, 0)),
         );
     });
 


### PR DESCRIPTION
Follow-up to #485. After fixing the three timezone-pinned tests there, I swept **every app and library** under `TZ=UTC` and `TZ=Pacific/Honolulu` to find any others. This was the only one left.

Same fault: the expectation is a fixed `+10:00` offset, but the clamp applies `bookable_hours` via `Date#setHours`, which is machine-local. On a UTC runner the expected `period_start` was exactly ten hours adrift, so `nx test explore` failed for anyone outside eastern Australia — and in CI whenever a change touched this library.

```
AssertionError: expected 1783584000 to be 1783548000
```
That difference is 36000 seconds. Ten hours.

### Verification

`explore` green under **UTC, Australia/Sydney, America/New_York, Pacific/Honolulu and Asia/Kolkata**.

The rest of the sweep came back clean — apps (`app-loader`, `assistant-panel`, `booking-panel`, `caterer-ui`, `concierge`, `control`, `enrolment`, `map-kiosk`, `outlook-addin`, `public`, `redirect`, `signage`, `signage-manager`, `stagehand`, `survey`, `timetable`, `visitor-kiosk`, `workplace`) and libraries (`assets`, `bookings`, `catering`, `common`, `components`, `events`, `form-fields`, `mocks`, `payments`, `users`) all pass with no unhandled errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)